### PR TITLE
Add pub to scene so components can be excluded by type_id

### DIFF
--- a/default_save.ron
+++ b/default_save.ron
@@ -1,0 +1,49 @@
+(
+  resources: {},
+  entities: {
+    15: (
+      components: {
+        "army::WeaponKind": Ranged,
+      },
+    ),
+    16: (
+      components: {
+        "army::SoldierWeapon": (Some(15)),
+        "army::Soldier": (),
+      },
+    ),
+    17: (
+      components: {
+        "army::WeaponKind": Ranged,
+      },
+    ),
+    18: (
+      components: {
+        "army::SoldierWeapon": (Some(17)),
+        "army::Soldier": (),
+      },
+    ),
+    19: (
+      components: {
+        "army::WeaponKind": Ranged,
+      },
+    ),
+    20: (
+      components: {
+        "army::SoldierWeapon": (Some(19)),
+        "army::Soldier": (),
+      },
+    ),
+    21: (
+      components: {
+        "army::WeaponKind": Ranged,
+      },
+    ),
+    22: (
+      components: {
+        "army::SoldierWeapon": (Some(21)),
+        "army::Soldier": (),
+      },
+    ),
+  },
+)

--- a/examples/army.rs
+++ b/examples/army.rs
@@ -45,7 +45,7 @@ fn main() {
         PreUpdate,
                 save_default().finalize_save_pipeline().run_if(check_for_save_keypress)
     )
-    .add_systems(PreUpdate, load_from_file(SaveFile::default().path).run_if(check_for_load_keypress))
+    .add_systems(PreUpdate, load_from_file().run_if(check_for_load_keypress))
     .run();
 }
 

--- a/examples/army.rs
+++ b/examples/army.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use bevy::prelude::*;
 use bevy_ecs::entity::{EntityMapper, MapEntities};
-use moonshine_save::prelude::*;
+use moonshine_save::{prelude::*, resources::SaveFile};
 
 const SAVE_PATH: &str = "army.ron";
 const HELP_TEXT: &str =
@@ -43,9 +43,9 @@ fn main() {
     // Add save/load pipelines:
     .add_systems(
         PreUpdate,
-        save_default().into_file_on_request::<SaveRequest>(),
+                save_default().finalize_save_pipeline().run_if(check_for_save_keypress)
     )
-    .add_systems(PreUpdate, load_from_file_on_request::<LoadRequest>())
+    .add_systems(PreUpdate, load_from_file(SaveFile::default().path).run_if(check_for_load_keypress))
     .run();
 }
 
@@ -69,6 +69,27 @@ impl SoldierBundle {
         }
     }
 }
+
+pub fn check_for_save_keypress(
+    keys: Res<Input<KeyCode>>,
+) -> bool{
+    if keys.just_pressed(KeyCode::AltRight) {
+        return true
+    } else {
+        return false
+    }
+}
+
+pub fn check_for_load_keypress(
+    keys: Res<Input<KeyCode>>,
+) -> bool{
+    if keys.just_pressed(KeyCode::AltLeft) {
+        return true
+    } else {
+        return false
+    }
+}
+
 
 #[derive(Component, Default, Reflect)]
 #[reflect(Component)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@
 pub mod load;
 pub mod save;
 
+pub mod resources;
+
 mod utils;
 
 /// Common elements for saving/loading world state.

--- a/src/load.rs
+++ b/src/load.rs
@@ -494,7 +494,7 @@ mod tests {
         {
             let mut app = App::new();
             app.add_plugins((MinimalPlugins, HierarchyPlugin, SavePlugin))
-                .add_systems(PreUpdate, save_default().into_file(PATH));
+                .add_systems(PreUpdate, save_default().finalize_save_pipeline());
 
             let entity = app
                 .world

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -1,0 +1,14 @@
+use bevy_ecs::prelude::*;
+
+#[derive(Resource, Clone)]
+pub struct SaveFile {
+    pub path: String,
+}
+
+impl Default for SaveFile {
+    fn default() -> Self {
+        Self {
+            path: "default_save.ron".to_string()
+        }
+    }
+}

--- a/src/save.rs
+++ b/src/save.rs
@@ -338,7 +338,7 @@ pub trait SaveIntoFileRequest {
 /// See [`save`], [`save_default`], [`save_all`] on how to create an instance of this type.
 pub struct SavePipelineBuilder<F: ReadOnlyWorldQuery> {
     query: PhantomData<F>,
-    scene: SaveFilter,
+    pub scene: SaveFilter,
 }
 
 /// Creates a [`SavePipelineBuilder`] which saves all entities with given entity filter `F`.

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -78,7 +78,7 @@ fn it_works() {
 
     {
         let mut app = app();
-        app.add_systems(PreUpdate, load_from_file(SAVE_PATH));
+        app.add_systems(PreUpdate, load_from_file());
 
         // Spawn an entity to offset indices
         app.world.spawn_empty();

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -54,7 +54,7 @@ fn app() -> App {
 fn it_works() {
     {
         let mut app = app();
-        app.add_systems(PreUpdate, save_default().into_file(SAVE_PATH));
+        app.add_systems(PreUpdate, save_default().finalize_save_pipeline());
 
         // Spawn some entities
         let bar = app.world.spawn(BarBundle::default()).id();

--- a/tests/resource.rs
+++ b/tests/resource.rs
@@ -39,7 +39,7 @@ fn it_works() {
 
     {
         let mut app = app();
-        app.add_systems(PreUpdate, load_from_file(SAVE_PATH));
+        app.add_systems(PreUpdate, load_from_file());
 
         app.update();
 

--- a/tests/resource.rs
+++ b/tests/resource.rs
@@ -23,7 +23,7 @@ fn it_works() {
             PreUpdate,
             save_default()
                 .include_resource::<Foo>()
-                .into_file(SAVE_PATH),
+                .finalize_save_pipeline(),
         );
 
         app.insert_resource(Foo);


### PR DESCRIPTION
I'm working on a library that integrates moonshine_save to include some extra utilities for managing saving/loading components with moonshine_save, and one of those features needs to be able to exclude components by TypeID. However, deny_by_id() is locked behind SceneFilter, which is not accessible due to scene being private.

This PR adds pub to scene to allow deny_by_id() to be accessible. 